### PR TITLE
templates: change main page header to h1

### DIFF
--- a/flask_wiki/templates/wiki/page.html
+++ b/flask_wiki/templates/wiki/page.html
@@ -16,7 +16,7 @@
         {% if can_edit_wiki %}
         <a class="btn btn-outline-primary btn-sm float-right" href="{{ url_for('wiki.edit', url=page.url) }}">Edit</a>
         {% endif %}
-        <h5>{{page.title}}</h5>
+        <h1>{{page.title}}</h1>
         {% for tag in page.tags.split(',') %}
         <span class="badge badge-primary">{{ tag }}</span>
         {% endfor %}


### PR DESCRIPTION
The {{ page.title }} is actually the main header of the page, then it
should be set to h1, not h5.

Closes #4.

Co-Authored-by: Igor Milhit <igor.milhit@rero.ch>
