### PR TITLE
files: restrict file management page

### DIFF
--- a/flask_wiki/templates/wiki/navigation.html
+++ b/flask_wiki/templates/wiki/navigation.html
@@ -7,6 +7,7 @@
   more details
 -->
 
+{% if can_edit_wiki %}
 <nav class="navbar navbar-expand navbar-light bg-light row mb-4">
   <ul class="navbar-nav">
     <li class="nav-item">
@@ -24,3 +25,4 @@
     </button>
   </form>
 </nav>
+{% endif %}

--- a/flask_wiki/views.py
+++ b/flask_wiki/views.py
@@ -176,7 +176,7 @@ def delete_file(filename):
     return redirect(url_for('wiki.files'))
 
 @blueprint.route('/files', methods=['GET', 'POST'])
-@can_read_permission
+@can_edit_permission
 def files():
     if request.method == 'POST' and current_app.config['WIKI_EDIT_UI_PERMISSION']():
         # check if the post request has the file part
@@ -207,7 +207,7 @@ def files():
 
 
 @blueprint.route('/search', methods=['GET'])
-@can_read_permission
+@can_edit_permission
 def search():
     query = request.args.get('q', '')
     results = current_wiki.search(query)


### PR DESCRIPTION
* Allows the access to the file management page only for the editor.
* Closes rero/rero-ils#1289.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>