### PR TITLE
template: use a wider space for the content

### DIFF
--- a/flask_wiki/static/css/wiki.css
+++ b/flask_wiki/static/css/wiki.css
@@ -15,23 +15,29 @@
   height: 400px;
 }
 
-.wiki-files {
-  position: relative;
-}
 .toast {
   position: absolute;
   top: 50px;
   left: 15px;
 }
-.wiki-files figure img {
-  max-width: 200px;
-  max-height: 200px;
+
+.wiki-files,
+.wiki-page,
+.wiki-editor {
+    position: relative;
 }
+
+.wiki-files figure img {
+  max-width: 15rem;
+  max-height: 15rem;
+}
+
 .wiki-files form .custom-file {
   position: relative;
   overflow: hidden;
   display: inline-block;
 }
+
 .wiki-files form input[type='file'] {
   font-size: 100px;
   position: absolute;

--- a/flask_wiki/templates/wiki/base.html
+++ b/flask_wiki/templates/wiki/base.html
@@ -21,7 +21,7 @@
   {% block styles %}
   <!-- Bootstrap CSS -->
   {{ bootstrap.load_css() }}
-  <!--font awsome -->
+  <!--font awesome -->
   <link href="{{ url_for('wiki.static', filename='css/font-awesome.min.css') }}" rel="stylesheet" />
   <link href="{{ url_for('wiki.static', filename='css/wiki.css') }}" rel="stylesheet" />
   {% endblock %}
@@ -35,7 +35,7 @@
     <a class="navbar-brand" href="#">{{ _('Flask-Wiki') }}</a>
   </nav>
 
-  <div class="container py-4">
+  <div class="container-fluid py-4">
     {{ render_messages(dismissible=True, dismiss_animate=True) }}
     {% block navigation %} {%- include "wiki/navigation.html" %} {% endblock %}
     {% block content %} {% endblock %}

--- a/flask_wiki/templates/wiki/editor.html
+++ b/flask_wiki/templates/wiki/editor.html
@@ -13,7 +13,7 @@
 {% set active_page = "editor" %}
 
 {% block content %}
-<div class="wiki-editor">
+<main class="wiki-editor col-md-10 offset-md-1 mt-4">
   <ul class="nav nav-tabs" role="tablist">
     <li class="nav-item">
       <a class="nav-link active" data-toggle="tab" id="edit-tab" href="#edit" role="tab" aria-controls="home"
@@ -75,6 +75,5 @@
       </div>
     </div>
   </div>
-</div>
-
+</main>
 {% endblock %}

--- a/flask_wiki/templates/wiki/files.html
+++ b/flask_wiki/templates/wiki/files.html
@@ -19,34 +19,39 @@
         {{ _('Copied to your clipboard') }}
     </div>
 </div>
-<div class="wiki-files">
-    {% if can_edit_wiki %}
-    <form class="float-right" method="post" enctype="multipart/form-data">
-        <div class="custom-file">
-            <button class="btn btn-outline-primary btn-sm"><i class="fa fa-upload" aria-hidden="true"></i> {{ _('Upload a file') }}</button>
-            <input class="custom-file-input" type="file" name="file" accept="image/*" />
-        </div>
-    </form>
-    {% endif %}
-
-    <h1>{{ _('List of Uploaded Files') }}</h1>
-    {% for file in files %}
-    <figure id="{{file}}" class="figure ml-4">
-        <img src="{{ url_for('uploaded_files', filename=file) }}" class="figure-img img-fluid rounded img-thumbnail"
-            alt="{{ file }}" />
-        <figcaption class="figure-caption text-center">
-            <a href="{{ url_for('uploaded_files', filename=file) }}">{{ file }}</a>
-            <button data-name="{{ file }}" data-link="{{ url_for('uploaded_files', filename=file) }}"
-                class="copy-md-code btn btn-sm btn-outline-primary">
-                <i class="fa fa-clipboard"></i>
-            </button>
-            <button data-toggle="modal" data-target="#deleteModal" id="{{file}}" class="delete-file btn btn-sm btn-outline-danger">
-                <i class="fa fa-trash"></i>
-            </button>
-        </figcaption>
-    </figure>
-
-    {% endfor %}
+<main class="row mt-4 wiki-files">
+    <article class="offset-md-1 col-md-10">
+        <header class="d-flex flex-column flex-lg-row justify-content-lg-between">
+            <h1>{{ _('List of Uploaded Files') }}</h1>
+            {% if can_edit_wiki %}
+            <form class="" method="post" enctype="multipart/form-data">
+                <div class="custom-file">
+                    <button class="btn btn-outline-primary btn-sm"><i class="fa fa-upload" aria-hidden="true"></i> {{ _('Upload a file') }}</button>
+                    <input class="custom-file-input" type="file" name="file" accept="image/*" />
+                </div>
+            </form>
+            {% endif %}
+        </header>
+        <article class="d-flex flex-wrap">
+            {% for file in files -%}
+            <figure id="{{file}}" class="figure m-2">
+                <img src="{{ url_for('uploaded_files', filename=file) }}" class="figure-img img-fluid rounded img-thumbnail"
+                                                                          alt="{{ file }}" />
+                <figcaption class="figure-caption text-center">
+                    <a href="{{ url_for('uploaded_files', filename=file) }}">{{ file }}</a>
+                    <button data-name="{{ file }}" data-link="{{ url_for('uploaded_files', filename=file) }}"
+                                                   class="copy-md-code btn btn-sm btn-outline-primary">
+                        <i class="fa fa-clipboard"></i>
+                    </button>
+                    <button data-toggle="modal" data-target="#deleteModal" id="{{file}}" class="delete-file btn btn-sm btn-outline-danger">
+                        <i class="fa fa-trash"></i>
+                    </button>
+                </figcaption>
+            </figure>
+            {%- endfor %}
+        </article>
+    </article>
+</main>
 
 <!-- Delete modal -->
 <div class="modal fade" id="deleteModal" tabindex="-1" role="dialog" aria-labelledby="deleteModalCenterTitle"

--- a/flask_wiki/templates/wiki/navigation.html
+++ b/flask_wiki/templates/wiki/navigation.html
@@ -7,22 +7,35 @@
   more details
 -->
 
-<nav class="navbar navbar-expand navbar-light bg-light row mb-4">
-  <ul class="navbar-nav">
-    <li class="nav-item">
-      <a class="nav-link" href="{{ url_for('wiki.index') }}">{{ _('Home') }}</a>
-    </li>
-    {% if can_edit_wiki %}
-    <li class="nav-item">
-      <a class="nav-link" href="{{ url_for('wiki.files') }}">{{ _('Files') }}</a>
-    </li>
-    {% endif %}
-  </ul>
-  <form class="form-inline ml-auto" action="{{ url_for('wiki.search') }}">
-    <input class="form-control mr-sm-2" type="search" value="{{ query }}" name="q" placeholder="{{ _('Search') }}"
-      aria-label="{{ _('Search') }}" />
-    <button class="btn btn-outline-primary my-2 my-sm-0" type="submit">
-      {{ _('Search') }}
-    </button>
-  </form>
-</nav>
+<header class="row">
+    <nav class="navbar navbar-expand-lg navbar-light bg-light col-lg-10 offset-lg-1 justify-content-end">
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="navbar-nav mr-auto">
+            <li class="nav-item">
+                <a class="nav-link" href="{{ url_for('wiki.index') }}">{{ _('Home') }}</a>
+            </li>
+            {% if can_edit_wiki %}
+            <li class="nav-item">
+                <a class="nav-link" href="{{ url_for('wiki.files') }}">{{ _('Files') }}</a>
+            </li>
+            {% endif %}
+        </ul>
+        <form class="form-inline" action="{{ url_for('wiki.search') }}">
+            <div class="input-group">
+            <input class="form-control"
+                   type="search" value="{{ query }}"
+                   name="q" placeholder="{{ _('Search') }}"
+                   aria-label="{{ _('Search') }}" />
+            <div class="input-group-append">
+            <button class="btn btn-outline-primary" type="submit">
+                {{ _('Search') }}
+            </button>
+            </div>
+            </div>
+        </form>
+      </div>
+    </nav>
+</header>

--- a/flask_wiki/templates/wiki/page.html
+++ b/flask_wiki/templates/wiki/page.html
@@ -19,31 +19,48 @@
         {{ _('Copied to your clipboard') }}
     </div>
 </div>
-<div class="row mt-4 wiki-page">
-    <div class="col-md-8">
-        {% if can_edit_wiki %}
-        <a class="btn btn-outline-primary btn-sm float-right m-1" href="{{ url_for('wiki.edit', url=page.url) }}"><i class="fa fa-pencil"></i> {{ _('Edit') }}</a>
-        <button data-name="{{ page.title }}" data-link="{{ url_for('wiki.page', url=page.url) }}" class="copy-file-code btn btn-sm btn-outline-primary float-right m-1">
-            <i class="fa fa-clipboard"></i> {{ _('Copy link') }}
-        </button>
-        {% endif %}
-        <h1>{{page.title}}</h1>
-        <div class="text-muted float-right small">
-            <span>{{ _('Created:')}} {{ page.creation_datetime | date_format }} - {{ _('Last updated:')}} {{ page.modification_datetime | date_format }}</span>
-        </div>
-        {% for tag in page.tags.split(',') %}
-        <span class="badge badge-primary">{{ tag }}</span>
-        {% endfor %}
-        <hr>
+<main class="row mt-4 wiki-page">
+    <article class="col-md-8 offset-md-1">
+        <header class="d-flex flex-column justify-content-lg-between mb-4 pb-2 border-bottom">
+            <header class="wiki-page-header d-flex flex-column flex-lg-row justify-content-lg-between mb-2 mb-lg-0">
+            <h1 class="wiki-page-title mb-0">{{page.title}}</h1>
+            {% if can_edit_wiki %}
+            <div class="wiki-page-edition" role="group">
+                <button data-name="{{ page.title }}"
+                        data-link="{{ url_for('wiki.page', url=page.url) }}"
+                        class="copy-file-code btn btn-sm btn-outline-primary">
+                    <i class="fa fa-clipboard"></i> {{ _('Copy link') }}
+                </button>
+                <a type="button" class="btn btn-outline-primary btn-sm"
+                   href="{{ url_for('wiki.edit', url=page.url) }}">
+                   <i class="fa fa-pencil"></i> {{ _('Edit') }}
+                </a>
+            </div>
+            {% endif %}
+            </header>
+            <footer class="wiki-page-info d-flex flex-column flex-lg-row justify-content-lg-between">
+            {% if page.tags %}
+            <ul class="wiki-page-tags m-0 p-0">
+                {% for tag in page.tags.split(',') %}
+                <li class="badge badge-primary">{{ tag }}</li>
+                {% endfor %}
+            </ul>
+            {% endif %}
+            <div class="text-muted small">
+                <span>{{ _('Created:')}} {{ page.creation_datetime | date_format }} - {{ _('Last updated:')}} {{ page.modification_datetime | date_format }}</span>
+            </div>
+            </footer>
+        </header>
+        <article>
         {{ page }}
-    </div>
-    <div class="col-md-4">
+        </article>
+    </article>
+    <aside class="col-md-3">
         <div class="sticky-top pt-3">
             {% if page.toc %}
             <h5>{{ _('Table of contents') }}</h5>
             {{ page.toc }}
             {% endif %}
-        </div>
-    </div>
-</div>
+    </aside>
+</main>
 {% endblock %}

--- a/flask_wiki/templates/wiki/search.html
+++ b/flask_wiki/templates/wiki/search.html
@@ -13,43 +13,63 @@
 {% set active_page = "search" %}
 
 {% block content %}
-
-<div class="pb-3">
-  {{ results | length }} {{ ngettext('result', 'results', results | length) }}
-  <a href="{{ url_for('wiki.search', q='*') }}" class="btn btn-sm btn-outline-primary ml-2">{{ _("All languages") }}</a>
-</div>
-
 <div data-delay="1500" class="toast">
-  <div class="toast-header text-primary font-weight-bold">
-      Markdown
-  </div>
-  <div class="toast-body">
-      {{ _('Copied to your clipboard') }}
-  </div>
+    <div class="toast-header text-primary font-weight-bold">
+        Markdown
+    </div>
+    <div class="toast-body">
+        {{ _('Copied to your clipboard') }}
+    </div>
 </div>
-
-<ul class="list-group list-group-flush">
-  {%- for result in results -%}
-  <li class="list-group-item">
-    <a class="mr-2" href="{{ url_for('wiki.page', url=result.url) }}">
-      {{ result.title }}
-    </a>
-    <span class="badge badge-secondary">
-      {{ result.language | upper }}
-    </span>
-    {% for tag in result.tags.split(',') %}
-    <span class="badge badge-primary">{{ tag }}</span>
-    {% endfor %}
-    {% if can_edit_wiki %}
-    <span class="float-right">
-      <button data-name="{{ result.title }}" data-link="{{ url_for('wiki.page', url=result.url) }}" class="copy-file-code btn btn-sm btn-outline-primary ml-2">
-        <i class="fa fa-clipboard"></i> {{ _('Copy link') }}
-      </button>
-      <a class="btn btn-outline-primary btn-sm float-right ml-2" href="{{ url_for('wiki.edit', url=result.url) }}"><i class="fa fa-pencil"></i> {{ _('Edit') }}</a>
-    </span>
-    {% endif %}
-  </li>
-  {%- endfor -%}
-</ul>
+<main class="row mt-4 wiki-page">
+    <article class="col-md-10 offset-md-1">
+        <header>
+            <div class="pb-3">
+                {{ results | length }} {{ ngettext('result', 'results', results | length) }}
+                <a href="{{ url_for('wiki.search', q='*') }}" class="btn btn-sm btn-outline-primary ml-2">{{ _("All languages") }}</a>
+                </div>
+        </header>
+        <article>
+            <ul class="list-group list-group-flush">
+                {%- for result in results -%}
+                <li class="list-group-item">
+                    <article class="d-lg-flex justify-content-lg-between">
+                        <article class="mb-2">
+                            <h5 class="m-0">
+                                <a class="mr-2" href="{{ url_for('wiki.page', url=result.url) }}">
+                                    {{ result.title }}
+                                </a>
+                            </h5>
+                            <ul class="m-0 p-0">
+                                <li class="badge badge-secondary">
+                                    {{ result.language | upper }}
+                                </li>
+                                {% if result.tags %}
+                                {% for tag in result.tags.split(',') %}
+                                <li class="badge badge-primary">{{ tag }}</li>
+                                {% endfor %}
+                                {% endif %}
+                            </ul>
+                        </article>
+                        {% if can_edit_wiki %}
+                        <footer>
+                            <button data-name="{{ result.title }}"
+                                    data-link="{{ url_for('wiki.page', url=result.url) }}"
+                                    class="copy-file-code btn btn-sm btn-outline-primary">
+                                <i class="fa fa-clipboard"></i> {{ _('Copy link') }}
+                            </button>
+                            <a class="btn btn-outline-primary btn-sm"
+                               href="{{ url_for('wiki.edit', url=result.url) }}">
+                                <i class="fa fa-pencil"></i> {{ _('Edit') }}
+                            </a>
+                        </footer>
+                        {% endif %}
+                    </article>
+                </li>
+                {%- endfor -%}
+            </ul>
+        </article>
+    </article>
+</main>
 
 {% endblock %}


### PR DESCRIPTION
* Adapts layout to the fluid container.
* Improves responsiveness of the page.
* Collapses the menu in small screens.
* Moves the search input into a bootstrap input group.
* Closes rero#22.

Co-Authored-by: Igor Milhit <igor.milhit@rero.ch>
