### PR TITLE
permissions: allows all user to search for pages

### DIFF
--- a/flask_wiki/views.py
+++ b/flask_wiki/views.py
@@ -207,7 +207,6 @@ def files():
 
 
 @blueprint.route('/search', methods=['GET'])
-@can_edit_permission
 def search():
     query = request.args.get('q', '')
     results = current_wiki.search(query)


### PR DESCRIPTION
* Removes the permission restriction on the search page to allow user to
  search for help pages. The edit buttons are still restricted to the
  editor role.

Co-Authored-by: Igor Milhit <igor@milhit.ch>
