### PR TITLE
ext: fix getiterator

### DIFF
--- a/flask_wiki/markdown_ext.py
+++ b/flask_wiki/markdown_ext.py
@@ -25,7 +25,7 @@ class BootstrapExtension(Extension):
 class BootstrapTreeprocessor(Treeprocessor):
 
     def run(self, node):
-        for child in node.getiterator():
+        for child in node.iter():
             if child.tag == 'img':
                 child.set("class", "img-fluid mx-auto d-block")
             elif child.tag == 'table':


### PR DESCRIPTION
* Methods getchildren() and getiterator() of classes ElementTree and Element
  in the ElementTree module have been removed. They were deprecated in
  Python 3.2. Use iter(x) or list(x) instead of x.getchildren() and x.iter()
  or list(x.iter()) instead of x.getiterator(). (
  Contributed by Serhiy Storchaka in bpo-36543.)
  https://docs.python.org/3.9/whatsnew/3.9.html#removed

Co-Authored-by: Peter Weber <peter.weber@rero.ch>