### PR TITLE
feat: add basic test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,179 @@
 # Flask-Wiki
 
-## About
+A lightweight, file-based wiki system built as a Flask extension. Create, edit, search, and manage wiki pages stored as Markdown files on the filesystem -- no database required.
 
-Simple file based wiki for Flask.
+## Features
 
-## Getting started
+- Markdown pages with metadata (title, tags)
+- Full-text search powered by Whoosh
+- File/image uploads
+- WikiLinks (`[[Page Name]]` syntax)
+- Multilingual support
+- Rich editor with live preview (EasyMDE)
+- Customizable templates and permissions
 
-### Requirements
+## Installation
 
-* Python >=3.9.2,<3.13
-* [uv](https://docs.astral.sh/uv/)
+```bash
+pip install flask-wiki
+```
 
-### Install dev environment
+## Quick start
 
-- Clone the git repository
-- run `uv sync --frozen`
-- `cd examples`
-- `uv run flask flask_wiki init-index`
-- `uv run flask flask_wiki index`
-- then `uv run flask run --debug`
-- go to http://localhost:5000/help
+```python
+from flask import Flask
+from flask_wiki import Wiki
+
+app = Flask(__name__)
+app.config['SECRET_KEY'] = 'your-secret-key'
+Wiki(app)
+```
+
+Or using the application factory pattern:
+
+```python
+from flask import Flask
+from flask_wiki import Wiki
+
+wiki = Wiki()
+
+def create_app():
+    app = Flask(__name__)
+    app.config['SECRET_KEY'] = 'your-secret-key'
+    wiki.init_app(app)
+    return app
+```
+
+The wiki will be available at `/help` by default (configurable via `WIKI_URL_PREFIX`).
+
+### Initialize the search index
+
+Before using search, initialize the Whoosh index:
+
+```bash
+flask flask_wiki init-index
+flask flask_wiki index
+```
+
+## How it works
+
+Wiki pages are plain Markdown files stored in a content directory (`./data` by default). The URL structure mirrors the filesystem: `/help/guides/setup` maps to `data/guides/setup.md`.
+
+Each page file has an optional metadata header followed by the Markdown body:
+
+```markdown
+title: My Page Title
+tags: setup, guide
+
+# Content starts here
+
+Regular markdown content...
+```
+
+The wiki registers a Flask Blueprint with routes for viewing, editing, searching, and managing pages. Uploaded files (images) are stored in a subfolder and served via middleware.
+
+## Permissions
+
+Flask-Wiki uses a callable-based permission system. The host application provides functions that return `True` or `False` to control access. By default, everything is open (all lambdas return `True`).
+
+There are four permission settings:
+
+| Setting | Purpose |
+|---------|---------|
+| `WIKI_READ_VIEW_PERMISSION` | Controls access to read routes (view pages, search). Returns 403 if `False`. |
+| `WIKI_EDIT_VIEW_PERMISSION` | Controls access to edit routes (edit, delete, upload). Returns 403 if `False`. |
+| `WIKI_READ_UI_PERMISSION` | Controls visibility of read-related UI elements in templates. |
+| `WIKI_EDIT_UI_PERMISSION` | Controls visibility of edit buttons/links in templates. |
+
+Each permission is a callable (no arguments) that is evaluated per-request. This lets you integrate with any authentication system -- Flask-Login, session-based auth, API tokens, etc.
+
+### Example: integrating with Flask-Login
+
+```python
+from flask_login import current_user
+
+app.config['WIKI_READ_VIEW_PERMISSION'] = lambda: current_user.is_authenticated
+app.config['WIKI_EDIT_VIEW_PERMISSION'] = lambda: current_user.is_authenticated and current_user.has_role('editor')
+app.config['WIKI_EDIT_UI_PERMISSION'] = app.config['WIKI_EDIT_VIEW_PERMISSION']
+```
+
+The `VIEW` permissions are enforced server-side via route decorators. The `UI` permissions only toggle visibility of buttons and links in the templates -- they do not enforce access control on their own. Typically you'll set the UI permissions to match the view permissions, but you can separate them if needed (e.g., show a "log in to edit" button to anonymous users).
 
 ## Configuration
 
+### Content & storage
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `WIKI_HOME` | `'home'` | Default page for `/` |
+| `WIKI_URL_PREFIX` | `'/help'` | URL prefix for the wiki blueprint |
+| `WIKI_CONTENT_DIR` | `'./data'` | Directory for Markdown files |
+| `WIKI_UPLOAD_FOLDER` | `'./data/files'` | Directory for uploaded images |
+| `WIKI_ALLOWED_EXTENSIONS` | `{'png','jpg','jpeg','gif','svg'}` | Allowed upload types |
+| `WIKI_INDEX_DIR` | `'./index'` | Whoosh search index directory |
+
 ### Templates
 
-- WIKI_BASE_TEMPLATE = 'wiki/base.html'
-- WIKI_SEARCH_TEMPLATE = 'wiki/search.html'
-- WIKI_NOT_FOUND_TEMPLATE = 'wiki/404.html'
-- WIKI_FORBIDDEN_TEMPLATE = 'wiki/403.html'
-- WIKI_EDITOR_TEMPLATE = 'wiki/editor.html'
-- WIKI_FILES_TEMPLATE = 'wiki/files.html'
-- WIKI_PAGE_TEMPLATE = 'wiki/page.html'
+All templates can be overridden by setting these config values to your own template paths:
 
-### Miscs
+| Key | Default |
+|-----|---------|
+| `WIKI_BASE_TEMPLATE` | `'wiki/base.html'` |
+| `WIKI_PAGE_TEMPLATE` | `'wiki/page.html'` |
+| `WIKI_EDITOR_TEMPLATE` | `'wiki/editor.html'` |
+| `WIKI_SEARCH_TEMPLATE` | `'wiki/search.html'` |
+| `WIKI_FILES_TEMPLATE` | `'wiki/files.html'` |
+| `WIKI_NOT_FOUND_TEMPLATE` | `'wiki/404.html'` |
+| `WIKI_FORBIDDEN_TEMPLATE` | `'wiki/403.html'` |
 
-- WIKI_HOME = 'home'
-- WIKI_CURRENT_LANGUAGE = lambda: 'en'
-- WIKI_LANGUAGES = {'en': 'English', 'fr': 'French', 'de': 'German', 'it': 'Italian'}
-- WIKI_URL_PREFIX = '/help'
-- WIKI_CONTENT_DIR = './data'
-- WIKI_INDEX_DIR = './index'
-- WIKI_UPLOAD_FOLDER = os.path.join(WIKI_CONTENT_DIR, 'files')
-- WIKI_ALLOWED_EXTENSIONS = {'png', 'jpg', 'jpeg', 'gif', 'svg'}
-- WIKI_MARKDOWN_EXTENSIONS = set(('codehilite', 'fenced_code'))
+### Internationalization
 
-### Permissions
+| Key | Default | Description |
+|-----|---------|-------------|
+| `WIKI_CURRENT_LANGUAGE` | `lambda: 'en'` | Callable returning the current language code |
+| `WIKI_LANGUAGES` | `{'en': 'English', 'fr': 'French', 'de': 'German', 'it': 'Italian'}` | Available languages |
 
-- WIKI_EDIT_VIEW_PERMISSION = lambda: True
-- WIKI_READ_VIEW_PERMISSION = lambda: True
-- WIKI_EDIT_UI_PERMISSION = WIKI_EDIT_VIEW_PERMISSION
-- WIKI_READ_UI_PERMISSION = WIKI_READ_VIEW_PERMISSION
+Pages can have per-language variants using filename suffixes: `page_fr.md`, `page_de.md`, etc. The wiki automatically loads the correct variant based on `WIKI_CURRENT_LANGUAGE`.
+
+### Markdown
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `WIKI_MARKDOWN_EXTENSIONS` | `{'codehilite', 'fenced_code'}` | Additional Python-Markdown extensions |
+
+The extensions `toc`, `meta`, `tables`, and a built-in Bootstrap extension are always loaded.
+
+## Development
+
+### Requirements
+
+- Python >=3.10,<3.15
+- [uv](https://docs.astral.sh/uv/)
+
+### Setup
+
+```bash
+git clone <repo-url>
+cd flask-wiki
+uv sync --frozen
+```
+
+### Run the example app
+
+```bash
+cd examples
+uv run flask flask_wiki init-index
+uv run flask flask_wiki index
+uv run flask run --debug
+# Visit http://localhost:5000/help
+```
+
+### Run tests
+
+```bash
+uv run poe run_tests
+```
+
+## License
+
+BSD 3-Clause. See [LICENSE](LICENSE) for details.

--- a/flask_wiki/utils.py
+++ b/flask_wiki/utils.py
@@ -50,7 +50,7 @@ def wikilink(text, url_formatter=None):
     link_regex = re.compile(r"((?<!\<code\>)\[\[([^<].+?) \s*([|] \s* (.+?) \s*)?]])", re.X | re.U)
     for i in link_regex.findall(text):
         title = [i[-1] or i[1]][0]
-        url = url_formatter("display", url=clean_url(i[1]))
+        url = url_formatter("wiki.page", url=clean_url(i[1]))
         html_url = f"""<a href="{url}">{title}</a>"""
         text = re.sub(link_regex, html_url, text, count=1)
     return text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dev = [
 flask_wiki = "flask_wiki.cli:flask_wiki"
 
 [tool.pytest.ini_options]
-addopts = "--color=yes --doctest-modules --ignore=flask_wiki/config.py"
+addopts = "--color=yes --doctest-modules --ignore=flask_wiki/config.py --ignore=tests/data"
 testpaths = "tests flask_wiki"
 
 [tool.ruff]

--- a/scripts/test
+++ b/scripts/test
@@ -83,8 +83,7 @@ if [ $# -eq 0 ]
   then
     set -e
     pretests
-    # TODO: Uncomment when there is at least one test
-    # tests
+    tests
 fi
 
 success_msg+exit "Perfect ${PROGRAM} external! See you soon…"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,95 @@
+# This file is part of Flask-Wiki
+# Copyright (C) 2025 RERO
+#
+# Flask-Wiki is free software; you can redistribute it and/or modify
+# it under the terms of the Revised BSD License; see LICENSE file for
+# more details.
+
+"""Pytest fixtures for Flask-Wiki tests."""
+
+import os
+import shutil
+
+import pytest
+from flask import Flask
+from flask_babel import Babel
+from flask_bootstrap import Bootstrap4
+
+from flask_wiki import Wiki
+from flask_wiki.api import WikiBase
+
+TESTDATA_DIR = os.path.join(os.path.dirname(__file__), "data")
+
+# Minimal valid 1x1 PNG (67 bytes)
+TINY_PNG = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01"
+    b"\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde\x00\x00"
+    b"\x00\x0cIDATx\x9cc\xf8\x0f\x00\x00\x01\x01\x00\x05\x18"
+    b"\xd8N\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+
+@pytest.fixture(scope="module")
+def app(tmp_path_factory):
+    """Create a Flask application for testing."""
+    tmp = tmp_path_factory.mktemp("wiki")
+    content_dir = tmp / "data"
+    content_dir.mkdir()
+    upload_dir = content_dir / "files"
+    upload_dir.mkdir()
+    index_dir = tmp / "index"
+    index_dir.mkdir()
+
+    # Copy test data into the temp content dir
+    for filename in os.listdir(TESTDATA_DIR):
+        src = os.path.join(TESTDATA_DIR, filename)
+        if os.path.isfile(src):
+            shutil.copy2(src, content_dir / filename)
+
+    app = Flask(__name__)
+    app.config.update(
+        TESTING=True,
+        SECRET_KEY="test-secret",
+        WTF_CSRF_ENABLED=False,
+        WIKI_CONTENT_DIR=str(content_dir),
+        WIKI_UPLOAD_FOLDER=str(upload_dir),
+        WIKI_INDEX_DIR=str(index_dir),
+        WIKI_CURRENT_LANGUAGE=lambda: "en",
+        WIKI_LANGUAGES={"en": "English", "fr": "French"},
+    )
+    app.config["SERVER_NAME"] = "localhost"
+    Bootstrap4(app)
+    Babel(app, default_locale="en")
+    Wiki(app)
+
+    # Register endpoint expected by base template
+    @app.route("/language/<ln>")
+    def change_language(ln):
+        return ""
+
+    # Initialize search index and index test pages
+    with app.app_context():
+        wiki = WikiBase(str(content_dir))
+        wiki.init_search_index()
+        wiki.index_all_pages()
+
+    yield app
+
+
+@pytest.fixture(scope="module")
+def client(app):
+    """Create a test client."""
+    return app.test_client()
+
+
+@pytest.fixture()
+def wiki(app):
+    """Create a WikiBase instance inside a request context."""
+    with app.test_request_context():
+        yield WikiBase(app.config["WIKI_CONTENT_DIR"])
+
+
+@pytest.fixture()
+def png_file():
+    """Return a minimal valid PNG as bytes."""
+    return TINY_PNG

--- a/tests/data/home.md
+++ b/tests/data/home.md
@@ -1,0 +1,6 @@
+title: Home
+tags: welcome, main
+
+# Welcome
+
+This is the home page with a [[sample|link to sample]].

--- a/tests/data/sample.md
+++ b/tests/data/sample.md
@@ -1,0 +1,10 @@
+title: Sample Page
+tags: test, example
+
+# Sample
+
+Some content for **testing** purposes.
+
+| Column A | Column B |
+|----------|----------|
+| cell 1   | cell 2   |

--- a/tests/data/sample_fr.md
+++ b/tests/data/sample_fr.md
@@ -1,0 +1,6 @@
+title: Page Exemple
+tags: test, exemple
+
+# Exemple
+
+Contenu en français.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,268 @@
+# This file is part of Flask-Wiki
+# Copyright (C) 2025 RERO
+#
+# Flask-Wiki is free software; you can redistribute it and/or modify
+# it under the terms of the Revised BSD License; see LICENSE file for
+# more details.
+
+"""Tests for flask_wiki.api (Processor, Page, WikiBase)."""
+
+import os
+
+import pytest
+from werkzeug.exceptions import NotFound
+
+from flask_wiki.api import Page, Processor, WikiBase
+
+
+def test_processor_render(app):
+    """Test that Processor converts markdown to HTML with metadata."""
+    with app.test_request_context():
+        text = "title: Test\ntags: a, b\n\n# Hello\n\nSome **bold** text."
+        processor = Processor(text)
+        html, _body, meta, _toc = processor.process()
+
+        assert "<h1" in html
+        assert "<strong>bold</strong>" in html
+        assert meta["title"] == "Test"
+        assert meta["tags"] == "a, b"
+
+
+def test_processor_toc(app):
+    """Test that Processor generates a table of contents."""
+    with app.test_request_context():
+        text = "title: T\n\n## Section One\n\n## Section Two"
+        processor = Processor(text)
+        _html, _body, _meta, toc = processor.process()
+
+        assert toc  # truthy when there are headings
+        toc_html = toc.__html__()
+        assert "Section One" in toc_html
+        assert "Section Two" in toc_html
+
+
+def test_processor_fenced_code(app):
+    """Test that fenced code blocks are rendered."""
+    with app.test_request_context():
+        text = "title: T\n\n```python\nprint('hello')\n```"
+        processor = Processor(text)
+        html, _body, _meta, _toc = processor.process()
+
+        assert "<code" in html
+        assert "print" in html
+
+
+def test_processor_table_bootstrap(app):
+    """Test that tables get Bootstrap classes."""
+    with app.test_request_context():
+        text = "title: T\n\n| A | B |\n|---|---|\n| 1 | 2 |"
+        processor = Processor(text)
+        html, _body, _meta, _toc = processor.process()
+
+        assert "table-striped" in html
+
+
+def test_page_load_and_render(app):
+    """Test loading and rendering a page from disk."""
+    with app.test_request_context():
+        path = os.path.join(app.config["WIKI_CONTENT_DIR"], "home.md")
+        page = Page(path, "home")
+
+        assert page.title == "Home"
+        assert "welcome" in page.tags
+        assert "<h1" in page.html
+        assert page.raw_body  # non-empty text
+
+
+def test_page_save(app):
+    """Test saving a new page and reading it back."""
+    with app.test_request_context():
+        content_dir = app.config["WIKI_CONTENT_DIR"]
+        path = os.path.join(content_dir, "newpage.md")
+
+        try:
+            # Create and save
+            page = Page(path, "newpage", new=True)
+            page["title"] = "New Page"
+            page["tags"] = "new"
+            page.body = "# New\n\nFresh content."
+            page.save()
+
+            # Verify file exists
+            assert os.path.isfile(path)
+
+            # Read it back
+            page2 = Page(path, "newpage")
+            assert page2.title == "New Page"
+            assert "Fresh content" in page2.raw_body
+        finally:
+            if os.path.isfile(path):
+                os.remove(path)
+
+
+def test_page_language_variant(app):
+    """Test that language-specific files are loaded when available."""
+    with app.test_request_context():
+        content_dir = app.config["WIKI_CONTENT_DIR"]
+        original_language = app.config.get("WIKI_CURRENT_LANGUAGE")
+
+        try:
+            # With language set to "fr", should load sample_fr.md
+            app.config["WIKI_CURRENT_LANGUAGE"] = lambda: "fr"
+            wiki = WikiBase(content_dir)
+            page = wiki.get("sample")
+            assert page is not None
+            assert page.title == "Page Exemple"
+
+            # Reset to "en", should load sample.md (no sample_en.md exists)
+            app.config["WIKI_CURRENT_LANGUAGE"] = lambda: "en"
+            wiki = WikiBase(content_dir)
+            page = wiki.get("sample")
+            assert page is not None
+            assert page.title == "Sample Page"
+        finally:
+            if original_language is not None:
+                app.config["WIKI_CURRENT_LANGUAGE"] = original_language
+
+
+def test_wiki_list_pages(wiki):
+    """Test listing all pages."""
+    pages = wiki.list_pages()
+    titles = [p.title for p in pages]
+
+    assert "Home" in titles
+    assert "Sample Page" in titles
+    assert len(pages) >= 2
+
+
+def test_wiki_get_or_404(app):
+    """Test get_or_404 for existing and missing pages."""
+    with app.test_request_context():
+        wiki = WikiBase(app.config["WIKI_CONTENT_DIR"])
+
+        # Existing page
+        page = wiki.get_or_404("home")
+        assert page.title == "Home"
+
+        # Missing page
+        with pytest.raises(NotFound):
+            wiki.get_or_404("does_not_exist")
+
+
+def test_wiki_get_bare(wiki):
+    """Test get_bare returns a new Page for non-existing URLs."""
+    page = wiki.get_bare("brand_new_page")
+    assert isinstance(page, Page)
+    assert page.url == "brand_new_page"
+
+    # For existing pages, get_bare returns False
+    result = wiki.get_bare("home")
+    assert result is False
+
+
+def test_wiki_delete(app):
+    """Test deleting a page removes the file."""
+    with app.test_request_context():
+        content_dir = app.config["WIKI_CONTENT_DIR"]
+        wiki = WikiBase(content_dir)
+
+        # Create a page to delete
+        path = os.path.join(content_dir, "to_delete.md")
+        try:
+            page = Page(path, "to_delete", new=True)
+            page["title"] = "Delete Me"
+            page["tags"] = ""
+            page.body = "# Delete\n\nTemporary."
+            page.save()
+            assert os.path.isfile(path)
+
+            # Delete it
+            result = wiki.delete("to_delete")
+            assert result is True
+            assert not os.path.isfile(path)
+
+            # Deleting again returns False
+            result = wiki.delete("to_delete")
+            assert result is False
+        finally:
+            if os.path.isfile(path):
+                os.remove(path)
+
+
+def test_wiki_move(app):
+    """Test moving/renaming a page."""
+    with app.test_request_context():
+        content_dir = app.config["WIKI_CONTENT_DIR"]
+        wiki = WikiBase(content_dir)
+
+        src_path = os.path.join(content_dir, "moveme.md")
+        dst_path = os.path.join(content_dir, "moved.md")
+        try:
+            # Create a page to move
+            page = Page(src_path, "moveme", new=True)
+            page["title"] = "Move Me"
+            page["tags"] = ""
+            page.body = "# Move\n\nContent."
+            page.save()
+
+            # Move it
+            wiki.move("moveme", "moved")
+            assert not os.path.isfile(src_path)
+            assert os.path.isfile(dst_path)
+        finally:
+            for p in (src_path, dst_path):
+                if os.path.isfile(p):
+                    os.remove(p)
+
+
+def test_wiki_move_path_traversal(app):
+    """Test that path traversal is blocked in move."""
+    with app.test_request_context():
+        content_dir = app.config["WIKI_CONTENT_DIR"]
+        wiki = WikiBase(content_dir)
+
+        src_path = os.path.join(content_dir, "safe.md")
+        try:
+            # Create a source page
+            page = Page(src_path, "safe", new=True)
+            page["title"] = "Safe"
+            page["tags"] = ""
+            page.body = "# Safe\n\nContent."
+            page.save()
+
+            with pytest.raises(RuntimeError, match="outside content directory"):
+                wiki.move("safe", "../../../etc/evil")
+        finally:
+            if os.path.isfile(src_path):
+                os.remove(src_path)
+
+
+def test_wiki_get_tags(wiki):
+    """Test retrieving all tags across pages."""
+    tags = wiki.get_tags()
+    assert "test" in tags
+    assert "welcome" in tags
+
+
+def test_wiki_list_tagged_pages(wiki):
+    """Test filtering pages by tag."""
+    pages = wiki.list_tagged_pages("test")
+    titles = [p.title for p in pages]
+    assert "Sample Page" in titles
+
+
+def test_wiki_search(app):
+    """Test full-text search via Whoosh."""
+    from whoosh import index
+
+    with app.test_request_context():
+        wiki = WikiBase(app.config["WIKI_CONTENT_DIR"])
+        ix = index.open_dir(app.config["WIKI_INDEX_DIR"])
+        with ix.searcher() as searcher:
+            # Search for a word in the home page
+            results = wiki.search("Welcome", ix, searcher)
+            assert len(results) > 0
+
+            # Search for something that doesn't exist
+            results = wiki.search("xyznonexistent", ix, searcher)
+            assert len(results) == 0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,80 @@
+# This file is part of Flask-Wiki
+# Copyright (C) 2025 RERO
+#
+# Flask-Wiki is free software; you can redistribute it and/or modify
+# it under the terms of the Revised BSD License; see LICENSE file for
+# more details.
+
+"""Tests for flask_wiki.utils."""
+
+from flask_wiki.utils import clean_url, wikilink
+
+
+def test_clean_url_normalizes_spaces():
+    """Test that multiple spaces are reduced to one."""
+    assert clean_url("hello   world") == "hello world"
+    assert clean_url("  leading") == "leading"
+    assert clean_url("trailing  ") == "trailing"
+
+
+def test_clean_url_normalizes_backslashes():
+    """Test that backslashes are converted to forward slashes."""
+    assert clean_url("path\\to\\page") == "path/to/page"
+    assert clean_url("path\\\\to") == "path/to"
+
+
+def test_wikilink_simple(app):
+    """Test basic [[Page]] syntax."""
+    with app.test_request_context():
+        captured = {}
+
+        def url_fmt(endpoint, url):
+            captured["endpoint"] = endpoint
+            return f"/wiki/{url}"
+
+        result = wikilink("<p>See [[Home]]</p>", url_formatter=url_fmt)
+        assert captured["endpoint"] == "wiki.page"
+        assert '<a href="/wiki/Home">Home</a>' in result
+
+
+def test_wikilink_with_display_text(app):
+    """Test [[url|Display Text]] syntax."""
+    with app.test_request_context():
+        captured = {}
+
+        def url_fmt(endpoint, url):
+            captured["endpoint"] = endpoint
+            return f"/wiki/{url}"
+
+        result = wikilink("<p>See [[path/page|Click Here]]</p>", url_formatter=url_fmt)
+        assert captured["endpoint"] == "wiki.page"
+        assert '<a href="/wiki/path/page">Click Here</a>' in result
+
+
+def test_wikilink_inside_code_untouched(app):
+    """Test that wikilinks inside <code> blocks are left alone."""
+    with app.test_request_context():
+        captured = {}
+
+        def url_fmt(endpoint, url):
+            captured["endpoint"] = endpoint
+            return f"/wiki/{url}"
+
+        text = "<code>[[NotALink]]</code>"
+        result = wikilink(text, url_formatter=url_fmt)
+        assert "endpoint" not in captured
+        assert "[[NotALink]]" in result
+
+
+def test_wikilink_no_links(app):
+    """Test text without wikilinks is returned unchanged."""
+    with app.test_request_context():
+        captured = {}
+
+        def url_fmt(endpoint, url):
+            captured["endpoint"] = endpoint
+            return f"/wiki/{url}"
+
+        text = "<p>No links here</p>"
+        assert wikilink(text, url_formatter=url_fmt) == text
+        assert "endpoint" not in captured

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,170 @@
+# This file is part of Flask-Wiki
+# Copyright (C) 2025 RERO
+#
+# Flask-Wiki is free software; you can redistribute it and/or modify
+# it under the terms of the Revised BSD License; see LICENSE file for
+# more details.
+
+"""Tests for flask_wiki.views (routes and HTTP behavior)."""
+
+import io
+import os
+
+from tests.conftest import TINY_PNG
+
+
+def test_index_redirect(client):
+    """Test that / redirects to the home page."""
+    res = client.get("/help/")
+    assert res.status_code == 302
+    assert "/help/home/" in res.headers["Location"]
+
+
+def test_page_display(client):
+    """Test displaying an existing page."""
+    res = client.get("/help/home/")
+    assert res.status_code == 200
+    assert b"Home" in res.data
+
+
+def test_page_not_found(client):
+    """Test that a missing page returns 404."""
+    res = client.get("/help/nonexistent/")
+    assert res.status_code == 404
+
+
+def test_edit_page_get(client):
+    """Test GET on the edit page shows the form."""
+    res = client.get("/help/edit/home/")
+    assert res.status_code == 200
+    assert b"title" in res.data
+    assert b"body" in res.data
+
+
+def test_edit_page_post(client, app):
+    """Test POST to edit a page updates it."""
+    # Capture original page content before modifying
+    original_path = os.path.join(app.config["WIKI_CONTENT_DIR"], "home.md")
+    with open(original_path) as f:
+        original_content = f.read()
+
+    try:
+        res = client.post(
+            "/help/edit/home/",
+            data={"title": "Home Updated", "body": "# Updated\n\nNew content.", "tags": "updated"},
+            follow_redirects=True,
+        )
+        assert res.status_code == 200
+        assert b"Updated" in res.data
+    finally:
+        # Restore original content
+        with open(original_path, "w") as f:
+            f.write(original_content)
+
+
+def test_create_new_page(client, app):
+    """Test creating a new page via POST."""
+    path = os.path.join(app.config["WIKI_CONTENT_DIR"], "brandnew.md")
+    try:
+        res = client.post(
+            "/help/edit/brandnew/",
+            data={"title": "Brand New", "body": "# Brand New\n\nCreated via test.", "tags": "new"},
+            follow_redirects=True,
+        )
+        assert res.status_code == 200
+        assert b"Brand New" in res.data
+
+        # Verify page is accessible
+        res = client.get("/help/brandnew/")
+        assert res.status_code == 200
+    finally:
+        if os.path.isfile(path):
+            os.remove(path)
+
+
+def test_delete_page(client, app):
+    """Test deleting a page."""
+    # Create a page first
+    client.post(
+        "/help/edit/todelete/",
+        data={"title": "To Delete", "body": "# Delete Me\n\nTemporary.", "tags": ""},
+    )
+
+    res = client.get("/help/page/delete/todelete", follow_redirects=True)
+    assert res.status_code == 200
+
+    # Page should be gone
+    path = os.path.join(app.config["WIKI_CONTENT_DIR"], "todelete.md")
+    assert not os.path.isfile(path)
+
+
+def test_preview(client):
+    """Test the preview endpoint returns rendered HTML."""
+    res = client.post("/help/preview/", data={"body": "title: T\n\n# Hello\n\n**Bold**"})
+    assert res.status_code == 200
+    assert b"<h1" in res.data
+    assert b"<strong>Bold</strong>" in res.data
+
+
+def test_search_route(client):
+    """Test the search endpoint."""
+    res = client.get("/help/search?q=Welcome")
+    assert res.status_code == 200
+
+
+def test_files_page(client):
+    """Test the files management page loads."""
+    res = client.get("/help/files")
+    assert res.status_code == 200
+
+
+def test_file_upload_and_delete(client, app):
+    """Test uploading a valid file and then deleting it."""
+    data = {"file": (io.BytesIO(TINY_PNG), "upload_test.png")}
+    res = client.post("/help/files", data=data, content_type="multipart/form-data", follow_redirects=True)
+    assert res.status_code == 200
+
+    # File should exist on disk
+    upload_path = os.path.join(app.config["WIKI_UPLOAD_FOLDER"], "upload_test.png")
+    assert os.path.isfile(upload_path)
+
+    # Delete it
+    res = client.get("/help/file/delete/upload_test.png", follow_redirects=True)
+    assert res.status_code == 200
+    assert not os.path.isfile(upload_path)
+
+
+def test_file_upload_invalid_extension(client, app):
+    """Test that uploading a disallowed file type is rejected."""
+    data = {"file": (io.BytesIO(b"not a real exe"), "malware.exe")}
+    res = client.post("/help/files", data=data, content_type="multipart/form-data", follow_redirects=True)
+    assert res.status_code == 200
+
+    # File should NOT exist
+    upload_path = os.path.join(app.config["WIKI_UPLOAD_FOLDER"], "malware.exe")
+    assert not os.path.isfile(upload_path)
+
+
+def test_permissions_read_denied(app):
+    """Test that read permission denial returns 403."""
+    try:
+        app.config["WIKI_READ_VIEW_PERMISSION"] = lambda: False
+        with app.test_client() as c:
+            res = c.get("/help/home/")
+            assert res.status_code == 403
+    finally:
+        app.config["WIKI_READ_VIEW_PERMISSION"] = lambda: True
+
+
+def test_permissions_edit_denied(app):
+    """Test that edit permission denial returns 403."""
+    try:
+        app.config["WIKI_EDIT_VIEW_PERMISSION"] = lambda: False
+        with app.test_client() as c:
+            res = c.get("/help/edit/home/")
+            assert res.status_code == 403
+
+            res = c.get("/help/page/delete/home")
+            assert res.status_code == 403
+    finally:
+        app.config["WIKI_EDIT_VIEW_PERMISSION"] = lambda: True


### PR DESCRIPTION
- Add pytest tests for API, views, utils (conftest, test data fixtures)
- Rewrite README with usage guide, permissions docs, and full config reference
- Fix wikilink url_formatter to use 'wiki.page' instead of 'display'
- Enable pytest in test script and ignore tests/data in doctest collection