### PR TITLE
feat: let WIKI_URL_PREFIX carry a variable part

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,33 @@ The `VIEW` permissions are enforced server-side via route decorators. The `UI` p
 | `WIKI_ALLOWED_EXTENSIONS` | `{'png','jpg','jpeg','gif','svg'}` | Allowed upload types |
 | `WIKI_INDEX_DIR` | `'./index'` | Whoosh search index directory |
 
+#### A prefix with a variable part
+
+`WIKI_URL_PREFIX` may carry variable parts, which is how an application keeps a
+reader inside a section of its own -- a tenant, an organisation, a language:
+
+```python
+app.config["WIKI_URL_PREFIX"] = "/<org_code>/help"
+```
+
+The wiki serves `/unifr/help/setup` without ever knowing what `org_code` means:
+its views never see the value, and every URL it builds carries it back. That
+holds for the links of its templates, for the wikilinks of a page body, and
+therefore for the whole navigation -- a reader who enters through one prefix
+stays there.
+
+Any URL rule syntax will do, a converter of your own included, as long as the
+name does not collide with an argument of the wiki views -- `url` and
+`filename`: `"/<org:org_code>/help"`.
+
+Building such a URL from outside the wiki, from a footer for instance, means
+passing the value: `url_for('wiki.index', org_code='unifr')`.
+
+The uploaded files hang from the static part of the prefix, `/help/files/` in
+the example above, whatever the prefix a reader came through. A WSGI mount
+point carries no variable, and neither does the URL of an image written in a
+page.
+
 ### Templates
 
 All templates can be overridden by setting these config values to your own template paths:

--- a/flask_wiki/__init__.py
+++ b/flask_wiki/__init__.py
@@ -3,10 +3,15 @@
 
 """This extension create a wiki from a tree directory."""
 
+import re
+
 from werkzeug.middleware.shared_data import SharedDataMiddleware
 
 from . import config
 from .views import blueprint
+
+# a variable part of a URL rule: <name>, <converter:name> or <converter(arg):name>
+VARIABLE_PART = re.compile(r"/?<(?:[^<>:]+:)?([^<>:]+)>")
 
 
 class Wiki:
@@ -18,22 +23,29 @@ class Wiki:
         :param app: Flask application instance, or None for deferred initialization
         """
         self.app = app
+        self.prefix_variables = []
         if app is not None:
             self.init_app(app)
 
     def init_app(self, app):
         """Flask application initialization."""
         self.init_config(app)
-        app.register_blueprint(blueprint, url_prefix=app.config.get("WIKI_URL_PREFIX"))
+        prefix = app.config["WIKI_URL_PREFIX"]
+        self.prefix_variables = VARIABLE_PART.findall(prefix)
+        # the uploaded files hang from the static part of the prefix: a WSGI
+        # mount point carries no variable, and neither does the URL of an image
+        # written in a page
+        files_prefix = VARIABLE_PART.sub("", prefix)
+        app.register_blueprint(blueprint, url_prefix=prefix)
         app.add_url_rule(
-            app.config.get("WIKI_URL_PREFIX") + "/files/<filename>",
+            f"{files_prefix}/files/<filename>",
             "uploaded_files",
             build_only=True,
         )
 
         app.wsgi_app = SharedDataMiddleware(
             app.wsgi_app,
-            {app.config.get("WIKI_URL_PREFIX") + "/files": app.config["WIKI_UPLOAD_FOLDER"]},
+            {f"{files_prefix}/files": app.config["WIKI_UPLOAD_FOLDER"]},
         )
         app.extensions["flask-wiki"] = self
 

--- a/flask_wiki/api.py
+++ b/flask_wiki/api.py
@@ -99,18 +99,25 @@ class Processor:
             current = processor(current)
         self.final = current
 
-    def process(self):
+    def process(self, *, postprocess=True):
         """Run the full processing suite.
 
         Runs the full suite of processing on the given text, all
         pre and post processing, markdown rendering and meta data
         handling.
+
+        :param bool postprocess: if False, skip the postprocessors. They build
+            the URL of the wikilinks, which needs a request; the metadata and
+            the raw body, all the search index stores, do not.
         """
         self.process_pre()
         self.process_markdown()
         self.split_raw()
         self.process_meta()
-        self.process_post()
+        if postprocess:
+            self.process_post()
+        else:
+            self.final = self.html
 
         return self.final, self.markdown, self.meta, TOC(self.toc, self.md.toc_tokens)
 
@@ -137,7 +144,7 @@ class TOC:
 class Page:
     """A page of the wiki."""
 
-    def __init__(self, path, url, *, new=False, fallback_language=None):
+    def __init__(self, path, url, *, new=False, fallback_language=None, postprocess=True):
         """Initialize a wiki page.
 
         :param path: filesystem path to the page file
@@ -145,6 +152,8 @@ class Page:
         :param bool new: if True, skip loading and rendering (page does not exist yet)
         :param str fallback_language: language code of the variant served when the
             page does not exist in the current language, None otherwise
+        :param bool postprocess: if False, render without the postprocessors. Use it
+            outside a request, where the URL of a wikilink cannot be built.
         """
         self.path = path
         self.url = url
@@ -153,7 +162,7 @@ class Page:
         self.toc = None
         if not new:
             self.load()
-            self.render()
+            self.render(postprocess=postprocess)
 
     def __repr__(self):
         """Return a developer-readable string representation."""
@@ -164,10 +173,13 @@ class Page:
         with Path(self.path).open(encoding="utf-8") as f:
             self.content = f.read()
 
-    def render(self):
-        """Process and render a page."""
+    def render(self, *, postprocess=True):
+        """Process and render a page.
+
+        :param bool postprocess: if False, skip the postprocessors of the markdown
+        """
         processor = Processor(self.content)
-        self._html, self.body, self._meta, self.toc = processor.process()
+        self._html, self.body, self._meta, self.toc = processor.process(postprocess=postprocess)
 
         # Get creation and update times from file
         stat = Path(self.path).stat()
@@ -554,10 +566,13 @@ class WikiBase:
     def list_all_pages(self):
         """Build up a list of all the pages, one per file, language variants included.
 
+        The pages are rendered without the postprocessors, so their ``html`` carries
+        no wikilink: they are meant for indexing, not for display.
+
         :returns: a list of all the wiki pages
         :rtype: list
         """
-        pages = [Page(path, url) for path, url in self.list_files()]
+        pages = [Page(path, url, postprocess=False) for path, url in self.list_files()]
         return sorted(pages, key=lambda x: x.title.lower())
 
     def list_pages(self):

--- a/flask_wiki/api.py
+++ b/flask_wiki/api.py
@@ -273,6 +273,14 @@ class Page:
         self["tags"] = value
 
     @property
+    def tag_list(self):
+        """Return the page tags as a list, blank entries left out.
+
+        :rtype: list
+        """
+        return [tag.strip() for tag in self.tags.split(",") if tag.strip()]
+
+    @property
     def raw_body(self):
         """Return raw text of the body.
 
@@ -591,7 +599,7 @@ class WikiBase:
     def index_all_pages(self):
         """Index all the pages for the current wiki."""
         for page in self.list_all_pages():
-            Page.index(page)
+            page.index()
 
     def index_by(self, key):
         """Get an index based on the given key.
@@ -606,37 +614,29 @@ class WikiBase:
         :rtype: dict
         """
         pages = {}
-        for page in self.index():
-            value = getattr(page, key)
-            pre = pages.get(value, [])
-            pages[value] = pre.append(page)
+        for page in self.list_pages():
+            pages.setdefault(getattr(page, key), []).append(page)
         return pages
 
     def get_by_title(self, title):
-        """Get all page titles."""
-        pages = self.list_pages(attr="title")
-        return pages.get(title)
+        """Get the page carrying the given title, None if no page does.
+
+        :param str title: the title to look for
+        :rtype: Page
+        """
+        return next((page for page in self.list_pages() if page.title == title), None)
 
     def get_tags(self):
         """Get all tags."""
-        pages = self.list_pages()
         tags = {}
-        for page in pages:
-            pagetags = page.tags.split(",")
-            for tag in pagetags:
-                tag = tag.strip()  # noqa: PLW2901
-                if tag == "":
-                    continue
-                if tags.get(tag):
-                    tags[tag].append(page)
-                else:
-                    tags[tag] = [page]
+        for page in self.list_pages():
+            for tag in page.tag_list:
+                tags.setdefault(tag, []).append(page)
         return tags
 
     def list_tagged_pages(self, tag):
-        """Get a list of all pages that have a tag."""
-        pages = self.list_pages()
-        tagged = [page for page in pages if tag in page.tags]
+        """Get a list of all pages that carry the given tag."""
+        tagged = [page for page in self.list_pages() if tag in page.tag_list]
         return sorted(tagged, key=lambda x: x.title.lower())
 
     @property

--- a/flask_wiki/cli.py
+++ b/flask_wiki/cli.py
@@ -4,7 +4,6 @@
 """Click command-line interface for flask-wiki."""
 
 import click
-from flask import current_app
 from flask.cli import with_appcontext
 
 from .api import get_wiki
@@ -26,6 +25,4 @@ def init_index():
 @with_appcontext
 def index():
     """Index all wiki pages for whoosh search."""
-    # rendering a page builds the URL of its wikilinks, which needs a request
-    with current_app.test_request_context():
-        get_wiki().index_all_pages()
+    get_wiki().index_all_pages()

--- a/flask_wiki/views.py
+++ b/flask_wiki/views.py
@@ -12,6 +12,7 @@ from flask import (
     abort,
     current_app,
     flash,
+    g,
     redirect,
     render_template,
     request,
@@ -63,8 +64,12 @@ def can_edit_permission(func):
 # =======
 @blueprint.app_template_filter()
 def prune_url(path):
-    """Strip the wiki URL prefix and surrounding slashes from a path."""
-    return path.replace(current_app.config.get("WIKI_URL_PREFIX"), "").strip("/")
+    """Strip the wiki URL prefix and surrounding slashes from a path.
+
+    The prefix stripped is the one the reader came through, variable parts
+    included, so a pruned path stays usable to build a URL back into the wiki.
+    """
+    return path.removeprefix(url_for("wiki.index")).strip("/")
 
 
 @blueprint.app_template_filter()
@@ -101,6 +106,25 @@ def permission_processor():
         "can_edit_wiki": current_app.config.get("WIKI_EDIT_UI_PERMISSION")(),
         "can_read_wiki": current_app.config.get("WIKI_READ_UI_PERMISSION")(),
     }
+
+
+@blueprint.url_value_preprocessor
+def pull_prefix_values(_endpoint, values):
+    """Take the variable parts of the URL prefix out of the view arguments.
+
+    A prefix such as ``/<organisation>/help`` lets an application keep a reader
+    inside a section of its own: the views of the wiki never see the value, and
+    it is put back into every URL the wiki builds by :func:`push_prefix_values`.
+    """
+    names = current_app.extensions["flask-wiki"].prefix_variables
+    g._wiki_url_values = {name: values.pop(name) for name in names if name in values}  # noqa: SLF001
+
+
+@blueprint.url_defaults
+def push_prefix_values(_endpoint, values):
+    """Carry the variable parts of the URL prefix over to the URLs being built."""
+    for name, value in getattr(g, "_wiki_url_values", {}).items():
+        values.setdefault(name, value)
 
 
 # MISCS

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,9 +25,12 @@ TINY_PNG = (
 )
 
 
-@pytest.fixture(scope="module")
-def app(tmp_path_factory):
-    """Create a Flask application for testing."""
+def make_app(tmp_path_factory, **config):
+    """Build a Flask application serving the test wiki.
+
+    :param tmp_path_factory: the pytest temporary directory factory
+    :param config: configuration overriding the defaults of the test wiki
+    """
     tmp = tmp_path_factory.mktemp("wiki")
     content_dir = tmp / "data"
     content_dir.mkdir()
@@ -43,6 +46,7 @@ def app(tmp_path_factory):
             shutil.copy2(src, content_dir / filename)
 
     app = Flask(__name__)
+    config.setdefault("SERVER_NAME", "localhost")
     app.config.update(
         TESTING=True,
         SECRET_KEY="test-secret",
@@ -54,8 +58,8 @@ def app(tmp_path_factory):
         WIKI_LANGUAGES={"en": "English", "fr": "French", "it": "Italian"},
         WIKI_FALLBACK_LANGUAGES=["en", "fr"],
         BOOTSTRAP_SERVE_LOCAL=True,
+        **config,
     )
-    app.config["SERVER_NAME"] = "localhost"
     Bootstrap4(app)
     Babel(app, default_locale="en")
     Wiki(app)
@@ -72,6 +76,12 @@ def app(tmp_path_factory):
         wiki.index_all_pages()
 
     return app
+
+
+@pytest.fixture(scope="module")
+def app(tmp_path_factory):
+    """Create a Flask application for testing."""
+    return make_app(tmp_path_factory)
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -420,11 +420,33 @@ def test_wiki_get_tags(wiki):
     assert "welcome" in tags
 
 
+def test_wiki_get_by_title(wiki):
+    """Test retrieving a page by its title."""
+    assert wiki.get_by_title("Sample Page").url == "sample"
+    assert wiki.get_by_title("No Such Page") is None
+
+
+def test_wiki_index_by(wiki):
+    """Test grouping the pages by the value of one of their attributes."""
+    grouped = wiki.index_by("title")
+    assert [page.url for page in grouped["Sample Page"]] == ["sample"]
+
+
 def test_wiki_list_tagged_pages(wiki):
     """Test filtering pages by tag."""
     pages = wiki.list_tagged_pages("test")
     titles = [p.title for p in pages]
     assert "Sample Page" in titles
+
+
+def test_wiki_list_tagged_pages_matches_a_whole_tag(wiki):
+    """Test that a tag matches a whole tag, never a fragment of one."""
+    # 'welcome' is a tag of the home page, 'come' is only a fragment of it
+    assert [page.url for page in wiki.list_tagged_pages("welcome")] == ["home"]
+    assert wiki.list_tagged_pages("come") == []
+
+    # a tag written after a comma and a space is matched all the same
+    assert "Sample Page" in [page.title for page in wiki.list_tagged_pages("example")]
 
 
 def test_wiki_search(app):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,16 +4,15 @@
 """Tests for flask_wiki.cli (command-line interface)."""
 
 from flask_wiki.cli import index
+from tests.conftest import make_app
 
 
-def test_cli_index(app):
+def test_cli_index(tmp_path_factory):
     """Test that pages are indexed outside of a request."""
-    server_name = app.config["SERVER_NAME"]
-    try:
-        # without a server name, the URL of a wikilink, as held by the home
-        # page, can only be built within a request
-        app.config["SERVER_NAME"] = None
-        result = app.test_cli_runner().invoke(index)
-        assert result.exit_code == 0, result.exception
-    finally:
-        app.config["SERVER_NAME"] = server_name
+    # without a server name, the URL of a wikilink, as held by the home page,
+    # can only be built within a request: indexing must not need one
+    app = make_app(tmp_path_factory, SERVER_NAME=None)
+
+    result = app.test_cli_runner().invoke(index)
+
+    assert result.exit_code == 0, result.exception

--- a/tests/test_url_prefix.py
+++ b/tests/test_url_prefix.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: Fondation RERO+
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for a WIKI_URL_PREFIX carrying a variable part."""
+
+from pathlib import Path
+
+import pytest
+from flask import url_for
+
+from tests.conftest import TINY_PNG, make_app
+
+
+@pytest.fixture(scope="module")
+def prefixed_app(tmp_path_factory):
+    """Create an application serving the wiki under a variable URL prefix."""
+    # no server name: answer on any host, as an application serving a section
+    # on a domain of its own
+    return make_app(tmp_path_factory, WIKI_URL_PREFIX="/<organisation>/help", SERVER_NAME=None)
+
+
+@pytest.fixture(scope="module")
+def prefixed_client(prefixed_app):
+    """Create a test client for the application with a variable prefix."""
+    return prefixed_app.test_client()
+
+
+def test_pages_are_served_under_the_prefix(prefixed_client):
+    """Test that the wiki answers under the variable prefix, and only there."""
+    assert prefixed_client.get("/hepvs/help/home/").status_code == 200
+    assert prefixed_client.get("/help/home/").status_code == 404
+
+
+def test_urls_keep_the_prefix_they_were_reached_through(prefixed_client):
+    """Test that every URL the wiki builds carries the variable part back."""
+    html = prefixed_client.get("/hepvs/help/home/").data.decode()
+
+    # the links of the templates, built with url_for
+    assert 'href="/hepvs/help/"' in html
+    assert 'action="/hepvs/help/search"' in html
+    assert 'href="/hepvs/help/edit/home/"' in html
+
+    # and the wikilinks of the page body, built with url_for as well
+    assert 'href="/hepvs/help/sample/"' in html
+    assert "/help/sample/" not in html.replace("/hepvs/help/sample/", "")
+
+
+def test_the_404_page_offers_to_create_under_the_prefix(prefixed_client):
+    """Test that the link of the 404 page stays inside the prefix it was reached through."""
+    response = prefixed_client.get("/hepvs/help/missing/")
+
+    assert response.status_code == 404
+    assert 'href="/hepvs/help/edit/missing/"' in response.data.decode()
+
+
+def test_uploaded_files_hang_from_a_static_path(prefixed_app, prefixed_client):
+    """Test that the uploaded files are served outside the variable part.
+
+    A WSGI mount point carries no variable, and neither does the URL of an
+    image written in a page.
+    """
+    Path(prefixed_app.config["WIKI_UPLOAD_FOLDER"], "prefix_test.png").write_bytes(TINY_PNG)
+
+    with prefixed_app.test_request_context():
+        assert url_for("uploaded_files", filename="prefix_test.png") == "/help/files/prefix_test.png"
+
+    assert prefixed_client.get("/help/files/prefix_test.png").status_code == 200
+
+
+def test_each_host_keeps_its_own_prefix(prefixed_client):
+    """Test that a section served on a domain of its own stays on it.
+
+    The wiki builds relative URLs, so a reader keeps both the host and the
+    prefix they came through, and two portals of the same application never
+    send their readers to each other.
+    """
+    first = prefixed_client.get("/hepvs/help/home/", base_url="https://first.example.org").data.decode()
+    second = prefixed_client.get("/de/help/home/", base_url="https://second.example.org").data.decode()
+
+    assert 'href="/hepvs/help/sample/"' in first
+    assert 'href="/de/help/sample/"' in second
+
+    # neither page names a host, so no portal ever sends its readers to the other
+    for html in (first, second):
+        assert "first.example.org" not in html
+        assert "second.example.org" not in html


### PR DESCRIPTION
An application whose sections live under a code of their own -- a tenant, an organisation, a language -- had to reimplement the read routes of the wiki to keep that code in the URL, and its templates with them, or send its readers out of the section they were browsing.

The prefix may now carry variable parts. `url_value_preprocessor` pulls them out of the view arguments and `url_defaults` puts them back into every URL the wiki builds, so the views know nothing about them and the whole navigation stays inside the section, wikilinks included. The `prune_url` filter strips the prefix a reader came through rather than the configured one, so the create link of the 404 page stays there too. The name of a variable is the application's to choose, as long as it collides with no argument of the wiki views.

The uploaded files keep hanging from the static part of the prefix: a WSGI mount point carries no variable, and neither does the URL of an image written in a page.

Indexing follows, and had to: under a variable prefix, building the URL of a wikilink raises a BuildError whatever the server name, so the request context the CLI opened could no longer stand in for the values it lacks. The index stores the metadata and the raw body, never the postprocessed HTML, so `list_all_pages` renders without the postprocessors and its pages are no longer fit for display.

---

The branch carries a second commit, `fix: repair the page lookups that never ran`, independent of the prefix:

* `get_by_title` passed an `attr` argument `list_pages` does not take, so it raised TypeError on every call. It walks the pages and returns the first one carrying the title, None if there is none.
* `index_by` called `self.index`, which WikiBase does not define, and stored the result of `list.append` -- always None -- under each key.
* `list_tagged_pages` matched its argument against the raw tag string, so `come` returned the pages tagged `welcome`, and an empty tag the whole wiki. Tags are compared whole now, split once by `Page.tag_list`, which `get_tags` shares rather than splitting them a second way.
* `index_all_pages` called `Page.index(page)` where `page.index()` says it.
